### PR TITLE
Fixed indexing issue for retain() in Vec.py

### DIFF
--- a/sain/collections/vec.py
+++ b/sain/collections/vec.py
@@ -553,10 +553,14 @@ class Vec(typing.Generic[T], collections.MutableSequence[T], SpecContains[T]):
         """
         if not self._ptr:
             return
-
-        for idx, e in enumerate(self._ptr):
-            if not f(e):
+        
+        idx = 0
+        while idx < len(self._ptr):
+            if not f(self._ptr[idx]):
                 del self._ptr[idx]
+            else:
+                idx += 1
+
 
     def swap_remove(self, item: T) -> T:
         """Remove the first appearance of `item` from this vector and return it.


### PR DESCRIPTION
The implementation for retain() in Vec.py had an indexing issue because it would delete elements in place and increment idx regardless. This new implementation only increments idx if an element is not deleted.