### PR TITLE
Add `AsyncIterator` and `Stream`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,6 +30,8 @@
 
 import nox
 
+UNSTABLE_MODULES = ("async_iter",)
+
 
 @nox.session(reuse_venv=True)
 def pdoc(session: nox.Session) -> None:
@@ -105,7 +107,9 @@ def slotscheck(session: nox.Session) -> None:
         "lint",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
-    session.run("slotscheck", "-m", "sain", "--verbose")
+    session.run(
+        "slotscheck", "-m", "sain", "--verbose", "--exclude-modules", *UNSTABLE_MODULES
+    )
 
 
 @nox.session(reuse_venv=True)

--- a/sain/async_iter/__init__.py
+++ b/sain/async_iter/__init__.py
@@ -1,0 +1,103 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2022-Present, nxtlo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""Composable async iteration."""
+
+from __future__ import annotations
+
+__all__ = ("AsyncIterator", "Stream")
+
+import abc
+import typing
+
+from sain.macros import rustc_diagnostic_item
+from sain.macros import unstable
+from sain.option import NOTHING
+from sain.option import Some
+from collections import abc as collections
+
+T = typing.TypeVar("T", covariant=True)
+Item = typing.TypeVar("Item")
+
+if typing.TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from sain.option import Option
+
+    Poller: typing.TypeAlias = collections.AsyncIterable[T] | collections.Iterable[T]
+
+
+@rustc_diagnostic_item("async_iterator")
+@unstable(feature="async_iter", issue="257")
+class AsyncIterator(typing.Generic[Item], abc.ABC):
+    __slots__ = ()
+
+    # Required methods
+    @abc.abstractmethod
+    def poll_next(self) -> collections.Awaitable[Option[Item]]: ...
+    @abc.abstractmethod
+    async def __anext__(self) -> Item: ...
+
+    # Provided methods
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __await__(self) -> collections.MutableSequence[Item]:
+        return [item async for item in self]
+
+
+@unstable(feature="async_iter", issue="257")
+@typing.final
+class Stream(AsyncIterator[Item]):
+    __slots__ = ("_poller",)
+
+    def __init__(self, iterable: Poller[Item]) -> None:
+        self._poller = (
+            iterable.__aiter__()
+            if isinstance(iterable, collections.AsyncIterable)
+            else iterable.__iter__()
+        )
+
+    async def poll_next(self) -> Option[Item]:
+        try:
+            fut = await self.__anext__()
+        except (StopAsyncIteration, StopIteration):
+            return NOTHING
+
+        return Some(fut)
+
+    async def __anext__(self) -> Item:
+        if isinstance(self._poller, collections.AsyncIterable):
+            return await anext(self._poller)
+        else:
+            try:
+                return next(self._poller)
+            except StopIteration:
+                raise StopAsyncIteration

--- a/sain/iter/__init__.py
+++ b/sain/iter/__init__.py
@@ -64,12 +64,12 @@ import copy
 import itertools
 import typing
 
-from . import default as _default
-from . import futures
-from . import option as _option
-from . import result as _result
-from .macros import rustc_diagnostic_item
-from .macros import unsafe
+from sain import default as _default
+from sain import futures
+from sain import option as _option
+from sain import result as _result
+from sain.macros import rustc_diagnostic_item
+from sain.macros import unsafe
 
 Item = typing.TypeVar("Item")
 """The type of the item that is being yielded."""
@@ -83,9 +83,9 @@ AnyIter = typing.TypeVar("AnyIter", bound="Iterator[typing.Any]")
 if typing.TYPE_CHECKING:
     import _typeshed
 
-    from .collections.slice import Slice
-    from .collections.vec import Vec
-    from .option import Option
+    from sain.collections.slice import Slice
+    from sain.collections.vec import Vec
+    from sain.option import Option
 
     Collector = (
         collections.MutableSequence[Item]
@@ -259,7 +259,7 @@ class Iterator(
         assert to_vec == [0]
         ```
         """
-        from .collections.vec import Vec
+        from sain.collections.vec import Vec
 
         return Vec(_ for _ in self)
 
@@ -1153,7 +1153,7 @@ class TrustedIter(typing.Generic[Item], ExactSizeIterator[Item]):
         assert iterator.as_slice() == [2, 3]
         ```
         """
-        from .collections.slice import Slice
+        from sain.collections.slice import Slice
 
         return Slice(self.__slice_checked_get or ())
 


### PR DESCRIPTION
Tracking Issue: #257

adds the async version of `Iterator`, `AsyncIterator`, and async version of `Iter`, `Stream`.

```py
@rustc_diagnostic_item("async_iterator")
class AsyncIterator[Item](ABC):
    @abstractmethod
    async def poll_next(self) -> Option[Item]: ...
    @abstractmethod
    async def __anext__(self) -> Item: ...
    def __aiter__(self) -> Self: ...
    async def __await__(self) -> MutableSequence[Item]: ...

type Poller[T] = AsyncIterable[T] | Iterable[T]

@final
class Stream[T](AsyncIterator[T]):
    def __init__(self, it: Poller[T]) -> None: ...
    # impl AsyncIterator

# turns any iterable into a stream.
def into_stream[T](it: Poller[T]) -> Stream[T]: ...
```